### PR TITLE
Fix require

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,8 @@
 {
 	"presets": [
 		"es2015"
-	]
+	],
+	"plugins": [
+	 	"add-module-exports"
+ 	]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@streammedev/parrot-server",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Simple http server which returns a body with information about the request such as method, pathname, query parameters, and the request body. It is useful for testing.",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.16.0",
+    "babel-plugin-add-module-exports": "^0.2.1",
     "babel-preset-es2015": "^6.16.0",
     "babel-register": "^6.18.0",
     "happiness": "^7.1.2",

--- a/test/index.js
+++ b/test/index.js
@@ -4,6 +4,13 @@ import SimpleTestServer from '../';
 import url from 'url';
 import request from 'request';
 
+describe('module functionality', function () {
+	it('should support a simple require statement', function () {
+		const Sts = require('../');
+		assert.ok(new Sts(), 'initialize the server');
+	});
+});
+
 describe('SimpleTestServer', function () {
 	let server;
 	beforeEach(function (done) {


### PR DESCRIPTION
Currently, Babel is attaching the exported class to `module.exports.default`. This pr attaches it to `module.exports`.